### PR TITLE
fix: bound captured mihomo output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <a href="https://aikefu.tech">
-  <img src="https://raw.githubusercontent.com/GtxFury/FlyClash-Android/refs/heads/main/screenshots/file_0000000064a071f8a4eaf59cad35000a.png" alt="友情推荐" />
+  <img src="https://raw.githubusercontent.com/GtxFury/FlyClash-Android/refs/heads/main/screenshots/file_000000009a5c720bbf9028b8da087f14.png" alt="友情推荐" />
 </a>
 <a href="https://www.stromsend.xyz/#/register?code=tIhaARYV">
   <img src="screenshots/unnamed.jpg" alt="友情推荐" />

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+
+<a href="https://aikefu.tech">
+  <img src="screenshots/file_0000000064a071f8a4eaf59cad35000a.png" alt="友情推荐" />
+</a>
 <a href="https://www.stromsend.xyz/#/register?code=tIhaARYV">
   <img src="screenshots/unnamed.jpg" alt="友情推荐" />
 </a>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <a href="https://aikefu.tech">
-  <img src="screenshots/file_0000000064a071f8a4eaf59cad35000a.png" alt="友情推荐" />
+  <img src="https://raw.githubusercontent.com/GtxFury/FlyClash-Android/refs/heads/main/screenshots/file_0000000064a071f8a4eaf59cad35000a.png" alt="友情推荐" />
 </a>
 <a href="https://www.stromsend.xyz/#/register?code=tIhaARYV">
   <img src="screenshots/unnamed.jpg" alt="友情推荐" />

--- a/electron/main-process/bounded-output-buffer.js
+++ b/electron/main-process/bounded-output-buffer.js
@@ -1,0 +1,22 @@
+const DEFAULT_MAX_OUTPUT_CHARS = 256 * 1024;
+
+function appendBoundedOutput(currentOutput, nextChunk, maxChars = DEFAULT_MAX_OUTPUT_CHARS) {
+  if (!Number.isFinite(maxChars) || maxChars <= 0) {
+    return '';
+  }
+
+  const current = typeof currentOutput === 'string' ? currentOutput : '';
+  const next = Buffer.isBuffer(nextChunk) ? nextChunk.toString() : String(nextChunk ?? '');
+  const combined = current + next;
+
+  if (combined.length <= maxChars) {
+    return combined;
+  }
+
+  return combined.slice(-maxChars);
+}
+
+module.exports = {
+  DEFAULT_MAX_OUTPUT_CHARS,
+  appendBoundedOutput,
+};

--- a/electron/main-process/mihomo-service.js
+++ b/electron/main-process/mihomo-service.js
@@ -17,6 +17,7 @@ module.exports = function initMihomoService(context) {
   const { applyOverrides } = require('../ipc-handlers/overrides');
   const { getMihomoControllerParam, cleanupSocketFile } = require('../utils/socket-path');
   const { RunningMode, setRunningMode, getRunningMode, isServiceMode, getSocketPath, getServiceSocketPath, getSidecarSocketPath } = require('../utils/running-mode');
+  const { appendBoundedOutput } = require('./bounded-output-buffer');
   console.log('[mihomo-service] applyOverrides函数已导入:', typeof applyOverrides);
 
   async function waitForProcessExit(proc, timeoutMs = 5000) {
@@ -1200,7 +1201,7 @@ module.exports = function initMihomoService(context) {
 
       spawnedProcess.stdout.on('data', (data) => {
         const logContent = data.toString();
-        stdoutOutput += logContent;  // 收集 stdout 输出
+        stdoutOutput = appendBoundedOutput(stdoutOutput, logContent);  // 收集最近的 stdout 输出
         console.log(`mihomo stdout: ${logContent}`);
 
         // 检测 TUN 启动失败
@@ -1258,7 +1259,7 @@ module.exports = function initMihomoService(context) {
 
       spawnedProcess.stderr.on('data', (data) => {
         const errorText = data.toString();
-        stderrOutput += errorText;  // 收集 stderr 输出
+        stderrOutput = appendBoundedOutput(stderrOutput, errorText);  // 收集最近的 stderr 输出
         console.error(`mihomo stderr: ${errorText}`);
         safeSend('mihomo-error', errorText);
         process.stderr.write(data);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "node --test",
     "rebuild:native": "electron-rebuild -f -w better-sqlite3",
     "postinstall": "electron-builder install-app-deps",
     "prepare": "node scripts/prepare.mjs",

--- a/test/bounded-output-buffer.test.js
+++ b/test/bounded-output-buffer.test.js
@@ -1,0 +1,30 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  DEFAULT_MAX_OUTPUT_CHARS,
+  appendBoundedOutput,
+} = require('../electron/main-process/bounded-output-buffer');
+
+test('appendBoundedOutput keeps short output unchanged', () => {
+  const output = appendBoundedOutput('hello', '\nworld', 32);
+
+  assert.equal(output, 'hello\nworld');
+});
+
+test('appendBoundedOutput caps retained output and keeps newest content', () => {
+  let output = '';
+
+  output = appendBoundedOutput(output, '12345', 10);
+  output = appendBoundedOutput(output, '67890', 10);
+  output = appendBoundedOutput(output, 'abcde', 10);
+
+  assert.equal(output, '67890abcde');
+  assert.equal(output.length, 10);
+});
+
+test('appendBoundedOutput truncates a single large chunk to the configured limit', () => {
+  const output = appendBoundedOutput('', 'x'.repeat(DEFAULT_MAX_OUTPUT_CHARS + 5), 16);
+
+  assert.equal(output, 'x'.repeat(16));
+});


### PR DESCRIPTION
## Summary

This PR bounds the amount of mihomo stdout/stderr retained by the Electron main process.

The current code appends every mihomo output chunk to long-lived strings:

```js
stdoutOutput += logContent;
stderrOutput += errorText;
```

On a long-running session with regular mihomo connection logs, these strings can grow without limit and eventually trigger a main-process exception such as:

```text
RangeError: Invalid string length
at Socket.<anonymous> (.../electron/main-process/mihomo-service.js:1203:25)
```

Issues appear to be disabled for this repository, so I am including the bug report details in this PR body.

## Changes

- Add a small `appendBoundedOutput` helper that keeps only the latest captured output.
- Use it for both mihomo stdout and stderr capture in `mihomo-service.js`.
- Add Node's built-in `node:test` coverage for the buffer behavior.
- Add an `npm test` script for the new tests.

## Why

The captured stdout/stderr is used only for startup failure diagnostics, such as extracting fatal errors or showing the last few lines. Keeping the complete lifetime output is unnecessary and can crash the Electron main process after enough log output accumulates.

The helper keeps the newest output, preserving the existing diagnostics behavior that reports recent output while preventing unbounded string growth.

## Validation

- `node --test test/bounded-output-buffer.test.js` passes.
- `npm test` passes: 3 tests, 3 passing.
- `node --check electron/main-process/bounded-output-buffer.js` passes.
- `node --check electron/main-process/mihomo-service.js` passes.
- `node -e "require('./package.json')"` passes.
- `npm run build` passes.

`npm run lint` could not run a real lint pass because this repository currently has no ESLint config; `next lint` opens the interactive ESLint setup prompt and exits instead of linting.
